### PR TITLE
v0.92 Select, Form and extraData type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.92
+
+- `revertSearchField` clears inner input `Select`
+- Fix `extraData` type in subscribes to correctly accept object of path records
+- Add `reloadDataAfterSaveForm` prop for `Form` component
+
 ## 0.0.91
 
 - Value of `password` field no longer logs into the console when submitting form

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rt-design",
-	"version": "0.0.91",
+	"version": "0.0.92",
 	"description": "React technical design library",
 	"author": "Iron tech space",
 	"license": "MIT",

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -52,10 +52,11 @@ const Form = (props) => {
         footer,
         requestSaveForm,
         methodSaveForm,
-        processBeforeSaveForm
+        processBeforeSaveForm,
+        reloadDataAfterSaveForm,
     } = props;
 
-    /** Состояние первоначалной настройки компонента*/
+    /** Состояние первоначальной настройки компонента */
     const [loaded, setLoaded] = useState(false);
     const [antFormProps, setAntFormProps] = useState({});
     const [initFormData, setInitFormData] = useState({});
@@ -119,6 +120,7 @@ const Form = (props) => {
                         message: "Сохранение прошло успешно"
                     });
                     props.onFinish && props.onFinish(saveObject, response.data);
+                    if (reloadDataAfterSaveForm) setLoaded(false);
                 })
                 .catch(error => notificationError(error, 'Ошибка при сохранении') );
         } else if (props.onFinish)
@@ -193,14 +195,18 @@ Form.propTypes = {
     methodSaveForm: PropTypes.string,
 
     /** Функция обработки перед сохранением формы */
-    processBeforeSaveForm: PropTypes.func
+    processBeforeSaveForm: PropTypes.func,
+
+    /** Выполнить loadInitData после сохранения формы */
+    reloadDataAfterSaveForm: PropTypes.bool,
 };
 
 Form.defaultProps = {
     noPadding: false,
     scrollable: false,
     loadInitData: noop,
-    methodSaveForm: 'POST'
+    methodSaveForm: 'POST',
+    reloadDataAfterSaveForm: false,
 };
 
 const mapDispatchToProps = (dispatch) =>

--- a/src/components/Form/FormProps.ts
+++ b/src/components/Form/FormProps.ts
@@ -38,7 +38,10 @@ export interface FormProps extends AntFormProps{
      * Ссылка на функцию загрузки значений по умолчанию
      *
      * Пример: `(callBack) => callBack({})` */
-    loadInitData?: (callBack: (params: any) => void,row?:any) => void ,
+    loadInitData?: (callBack: (params: any) => void, row?:any) => void,
+
+    /** Выполнить loadInitData после сохранения формы */
+    reloadDataAfterSaveForm?: boolean,
 
     /** Запрос для автоматического сохранения формы */
     requestSaveForm?: Request;

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -93,7 +93,7 @@ const Select = props => {
     }, []);
 
     useEffect(() => {
-        _setSearchValue(revertSearchValue);
+        _setSearchValue('');
     }, [revertSearchValue]);
 
     useEffect(() => {
@@ -387,8 +387,8 @@ Select.propTypes = {
     /** Значение строки поиска */
     searchValue: PropTypes.string,
 
-    /** Сброс строки поиска вложенного инпута */
-    revertSearchValue: PropTypes.string,
+    /** Сброс строки поиска вложенного инпута по любому уникальному значению, например {} */
+    revertSearchValue: PropTypes.any,
 
     /** Имя параметра для поиска */
     searchParamName: PropTypes.string,

--- a/src/components/Select/SelectProps.tsx
+++ b/src/components/Select/SelectProps.tsx
@@ -19,6 +19,8 @@ export interface SelectProps<VT extends SelectValue = SelectValue> extends Omit<
     filter?: any;
     /** Значение строки поиска */
     searchValue?: string;
+    /** Сброс строки поиска вложенного инпута по любому уникальному значению, например {} */
+    revertSearchValue?: any,
     /** Имя параметра для поиска */
     searchParamName?: string;
     /** Имя параметра для поиска потерянного элемента */

--- a/src/components/core/wrappers.tsx
+++ b/src/components/core/wrappers.tsx
@@ -35,7 +35,7 @@ export interface StoreProps {
         /** Путь до объекта в Store */
         path: string;
         /** Путь к дополнительным данным которые будут переданы в onChange */
-        extraData?: string;
+        extraData?: string | Record<string, string>;
         /** Выполнить подписку при монтировании компонента
          * По умолчанию false */
         withMount?: boolean;


### PR DESCRIPTION
- `revertSearchField` clears inner input in `Select` component
- Fix `extraData` type in subscribes to correctly accept object of path records
- Add `reloadDataAfterSaveForm` prop for `Form` component